### PR TITLE
specify default Depth header

### DIFF
--- a/source/client.js
+++ b/source/client.js
@@ -118,7 +118,10 @@
 				request(
 					{
 						method: "PROPFIND",
-						uri: auth.url + path
+						uri: auth.url + path,
+						headers: {
+							Depth: 1
+						}
 					},
 					function(err, response, body) {
 						if (err || (response.statusCode < 200 && response.statusCode >= 300)) {
@@ -168,7 +171,10 @@
 				request(
 					{
 						method: "PROPFIND",
-						uri: auth.url + path
+						uri: auth.url + path,
+						headers: {
+							Depth: 1
+						}
 					},
 					function(err, response, body) {
 						if (err || (response.statusCode < 200 && response.statusCode >= 300)) {


### PR DESCRIPTION
some webdav servers (e.g. webdav.yandex.ru) assume Depth by default as Infinity and raise propfind-finite-depth error