### PR TITLE
Hit a bug, had to standardize on extracting filename (using unescaped version)

### DIFF
--- a/source/client.js
+++ b/source/client.js
@@ -60,7 +60,7 @@ function processDirectoryResult(path, dirResult, targetOnly) {
         //console.log(JSON.stringify(props, undefined, 4));
         var filename = processDirectoryResultFilename(
                 path,
-                processXMLStringValue(responseBro.iCanHaz1("d:href", "D:href"))
+                querystring.unescape(processXMLStringValue(responseBro.iCanHaz1("d:href", "D:href")))
             ).trim(),
             resourceType = processXMLStringValue(propsBro.iCanHaz1("lp1:resourcetype", "d:resourcetype", "D:resourcetype")),
             itemType = (resourceType.indexOf("d:collection") >= 0 || resourceType.indexOf("D:collection") >= 0) ?
@@ -72,7 +72,7 @@ function processDirectoryResult(path, dirResult, targetOnly) {
             // skip self or only self
             return;
         }
-        filename = querystring.unescape("/" + filename);
+        filename = "/" + filename;
         var item = {
                 filename: filename,
                 basename: pathTools.basename(filename),


### PR DESCRIPTION

Hit a bug, had to standardize on extracting filename (using unescaped version).  Had a webdav source that the user decided to use spaces and semicolons a lot.  The problem was semicolons in the filenames when even just getStat it would through an error because it could not find the file (wouldn't match on filename).

comment.... compare the unescape path and filename; hit a bug when the path directories and filename had escape values (space and semicolon)